### PR TITLE
Add creation date to video to avoid collision

### DIFF
--- a/asl_down.py
+++ b/asl_down.py
@@ -18,6 +18,7 @@ from bs4 import BeautifulSoup
 
 FOLDER = os.path.join("data", "videos")
 BASE_URL = 'https://www.signasl.org/sign/'
+SIGNS = ['Hello', 'Yes', 'No', 'My', 'Name']
 
 def scrape_warn(text, *args):
 
@@ -51,7 +52,9 @@ def download_video(name, url, start_time, duration_time):
             'home': file_path,
         },
         'outtmpl': {
-            'default': '{}-%(title)s.%(ext)s'.format(name),
+            #'default': '{}-%(title)s-%(uploader)s-%(id)s.%(ext)s'.format(name),
+            'default': '{}-%(title)s-%(upload_date)s.%(ext)s'.format(name),
+
         }
     }
 
@@ -176,4 +179,5 @@ def get_videos(name):
 
             download_video(sign, url, 0, 0)
 
-get_videos('test')
+for word in SIGNS:
+    get_videos(word)

--- a/asl_down.py
+++ b/asl_down.py
@@ -20,7 +20,6 @@ from utils.dataset_utils import load_dataset, save_landmarks_from_video
 
 FOLDER = os.path.join("data", "videos")
 BASE_URL = 'https://www.signasl.org/sign/'
-SIGNS = ['Hello', 'Yes', 'No', 'My', 'Name']
 
 def scrape_warn(text, *args):
 
@@ -54,7 +53,6 @@ def download_video(name, url, start_time, duration_time):
             'home': file_path,
         },
         'outtmpl': {
-            #'default': '{}-%(title)s-%(uploader)s-%(id)s.%(ext)s'.format(name),
             'default': '{}-%(title)s-%(upload_date)s.%(ext)s'.format(name),
 
         }
@@ -217,4 +215,5 @@ def get_videos(name, ignore=False):
 
             download_video(sign, url, 0, 0)
 
-
+for sing in SIGNS:
+    get_videos(sing)

--- a/asl_down.py
+++ b/asl_down.py
@@ -215,5 +215,3 @@ def get_videos(name, ignore=False):
 
             download_video(sign, url, 0, 0)
 
-for sing in SIGNS:
-    get_videos(sing)


### PR DESCRIPTION
Scraped videos will include the date of creation in the video file name to avoid overlapping names.